### PR TITLE
Added method to generate CSV string from an Array

### DIFF
--- a/activesupport/lib/active_support/core_ext/array/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/array/conversions.rb
@@ -208,4 +208,34 @@ class Array
       end
     end
   end
+
+  # this method is to generate a CSV string from an Array of Hashes to
+  # create a CSV file from it. The string that it returns
+  # can be written into a file to generate the equivalent CSV for the array.
+  # For Example, if you have an array of the details of 2 persons as below:
+  #
+  # persons = [
+  #   {name: 'Rohit', email: 'rohit@abc.com'},
+  #   {name: 'Amit', email: 'amit@xyz.com'}
+  # ]
+  #
+  # if you run the following code:
+  # -> persons.to_csv_str
+  # it will return the following string:
+  # -> "name,email\nRohit,rohit@abc.com\nAmit,amit@xyz.com\n"
+  # which can then be written to a file to get the equivalent CSV file for the Array
+  def to_csv_str
+    return if blank?
+    first_elem = self.first
+    if first_elem.is_a?(Hash)
+      header = first_elem.keys
+      csv_str = CSV.generate do |csv|
+        csv << header
+        self.each do |elem|
+          csv << elem.values
+        end
+      end
+    end
+    csv_str
+  end
 end

--- a/activesupport/lib/active_support/core_ext/hash/slice.rb
+++ b/activesupport/lib/active_support/core_ext/hash/slice.rb
@@ -45,4 +45,21 @@ class Hash
   def extract!(*keys)
     keys.each_with_object(self.class.new) { |key, result| result[key] = delete(key) if has_key?(key) }
   end
+  # Extracts the given set of keys from a Hash.
+  # Similar in use as `slice` but works with any kind of keys i.e.
+  # as if the Hash is a HashWithIndifferentAccess.
+  # Returns a hash containing the removed key/value pairs.
+  #
+  #   { a: 1, b: 2, c: 3, d: 4 }.extract(:a, :b)
+  #   # => {:a=>1, :b=>2}
+  #
+  #   { a: 1, b: 2, c: 3, d: 4 }.extract('a', 'b')
+  #   # => {:a=>1, :b=>2}
+  def extract(*keys)
+    keys.flatten!
+    keys.each_with_object({}) { |key, result|
+      key = self.has_key?(key.to_sym) ? key.to_sym : (self.has_key?(key.to_s) ? key.to_s : nil)
+      result[key] = self[key.to_sym] if key.present?
+    }
+  end
 end


### PR DESCRIPTION
### Summary

Added a method `to_csv_str` to generate the equivalent CSV string for an Array, which can then be written to a file to generate the equivalent CSV file for the Array.
### Other Information

This method is to generate a CSV string from an Array of Hashes to
create a CSV file from it. The string that it returns
can be written into a file to generate the equivalent CSV for the array.
For Example, if you have an array of the details of 2 persons as below:

```
persons = [
   {name: 'Rohit', email: 'rohit@abc.com'},
   {name: 'Amit', email: 'amit@xyz.com'}
]
```
if you run the following code:
-> `persons.to_csv_str`
it will return the following string:
-> `"name,email\nRohit,rohit@abc.com\nAmit,amit@xyz.com\n"`
which can then be written to a file to get the equivalent CSV file for the Array.